### PR TITLE
Fix config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "https://github.com/AY2223S1-CS2103T-T08-1/tp"
+repository: "AY2223S1-CS2103T-T08-1/tp"
 github_icon: "images/github-icon.png"
 
 plugins:


### PR DESCRIPTION
Fixes issue described in the 2103T issues forum where clicking the Github icon on our website led to a 404 error.